### PR TITLE
Remove incorrect Residue labels

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "program": "run.py",
             "console": "integratedTerminal",
-            "args": ["--algorithm", "smina", "-v", "-n", "[wip]-smina-docking"],
+            "args": ["--algorithm", "smina", "-v", "-r", "-n", "[wip]-smina-docking"],
             "justMyCode": false
         },
         {

--- a/nanome_docking/Docking.py
+++ b/nanome_docking/Docking.py
@@ -103,14 +103,14 @@ class Docking(nanome.AsyncPluginInstance):
                     raise Exception("Docking Call Failed, no poses returned. Please check logs")
 
                 docked_complex.full_name = f'{ligand.full_name} (Docked)'
-                ComplexUtils.convert_to_frames([docked_complex])
+                docked_complex = docked_complex.convert_to_frames()
                 # fix metadata sorting
                 if hasattr(self, 'set_scores'):
                     for molecule in docked_complex.molecules:
                         self.set_scores(molecule)
 
-                visualize_scores = params.get('visualize_scores', False)
-                if visualize_scores and hasattr(self, 'visualize_scores'):
+                visual_scores = params.get('visual_scores', False)
+                if visual_scores and hasattr(self, 'visualize_scores'):
                     self.visualize_scores(docked_complex)
 
                 docked_complex.set_current_frame(0)
@@ -125,7 +125,6 @@ class Docking(nanome.AsyncPluginInstance):
         self.update_structures_shallow(ligands)
 
         # Add docked complexes to workspace.
-        ComplexUtils.convert_to_conformers(output_complexes)
         self.add_result_to_workspace(output_complexes, receptor, site)
         self.send_notification(NotificationTypes.success, "Docking finished")
         return output_complexes
@@ -157,7 +156,7 @@ class SminaDocking(Docking):
         molecule.min_atom_score = float('inf')
         molecule.max_atom_score = float('-inf')
 
-        num_rgx = '(-?[\d.]+(?:e[+-]\d+)?)'
+        num_rgx = r'(-?[\d.]+(?:e[+-]\d+)?)'
         pattern = re.compile('<{},{},{}> {} {} {} {} {}'.format(*([num_rgx] * 8)), re.U)
         for associated in molecule.associateds:
             # make the labels pretty :)

--- a/nanome_docking/Docking.py
+++ b/nanome_docking/Docking.py
@@ -166,7 +166,9 @@ class SminaDocking(Docking):
             pose_score = associated['Minimized Affinity']
             for residue in molecule.residues:
                 residue.label_text = pose_score + " kcal/mol"
-                residue.labeled = True
+                # TODO: Re-enable this when core-bug with frame labels is fixed.
+                # https://nanome.slack.com/archives/CBDV1975K/p1641410333253500
+                residue.labeled = False
             interaction_terms = associated['Atomic Interaction Terms']
             interaction_values = re.findall(pattern, interaction_terms)
             for i, atom in enumerate(molecule.atoms):

--- a/nanome_docking/Docking.py
+++ b/nanome_docking/Docking.py
@@ -103,7 +103,7 @@ class Docking(nanome.AsyncPluginInstance):
                     raise Exception("Docking Call Failed, no poses returned. Please check logs")
 
                 docked_complex.full_name = f'{ligand.full_name} (Docked)'
-                docked_complex = docked_complex.convert_to_frames()
+                ComplexUtils.convert_to_frames([docked_complex])
                 # fix metadata sorting
                 if hasattr(self, 'set_scores'):
                     for molecule in docked_complex.molecules:

--- a/nanome_docking/menus/DockingMenu.py
+++ b/nanome_docking/menus/DockingMenu.py
@@ -45,7 +45,7 @@ class DockingMenu():
         self.loading_bar = self.ln_loading_bar.get_content()
 
     def get_params(self):
-        """Collect parameters from this menu and the Settings Menu."""
+        """Collect parameters from this menu."""
         params = {
             "modes": None,
             "align": None,


### PR DESCRIPTION
- Was trying to fix a bug where each frame of the docking results were showing the same score label, even when the scores were different
- We found that converting the complex back to conformers messed up the labels.
- When we fixed that though, we exposed a nanome-core bug where labels on a frame don't hide themselves when you switch to a new frame.
- Until core issue is fixed, we just aren't going to show any labels.